### PR TITLE
Implement SimpleQueryParser for query parsing

### DIFF
--- a/src/main/java/com/nilgil/book/search/parser/Operator.java
+++ b/src/main/java/com/nilgil/book/search/parser/Operator.java
@@ -1,0 +1,26 @@
+package com.nilgil.book.search.parser;
+
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+public enum Operator {
+    OR('|'),
+    NOT('-');
+
+    private final char symbol;
+
+    Operator(char symbol) {
+        this.symbol = symbol;
+    }
+
+    public static Optional<Operator> find(char symbol) {
+        for (Operator op : Operator.values()) {
+            if (op.getSymbol() == symbol) {
+                return Optional.of(op);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/nilgil/book/search/parser/QueryParser.java
+++ b/src/main/java/com/nilgil/book/search/parser/QueryParser.java
@@ -1,0 +1,7 @@
+package com.nilgil.book.search.parser;
+
+import com.nilgil.book.search.parser.model.Query;
+
+public interface QueryParser {
+    Query parse(String rawQuery);
+}

--- a/src/main/java/com/nilgil/book/search/parser/SimpleQueryParser.java
+++ b/src/main/java/com/nilgil/book/search/parser/SimpleQueryParser.java
@@ -1,0 +1,115 @@
+package com.nilgil.book.search.parser;
+
+import com.nilgil.book.search.parser.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class SimpleQueryParser implements QueryParser {
+
+    @Override
+    public Query parse(String rawQuery) {
+        if (rawQuery == null || rawQuery.isBlank()) {
+            return EmptyQuery.INSTANCE;
+        }
+
+        ParserState state = new ParserState(rawQuery);
+
+        return parseExpression(state);
+    }
+
+    private Query parseExpression(ParserState state) {
+        Query left = parseTermQuery(state);
+
+        while (!state.isEof()) {
+            state.consumeWhitespace();
+            if (state.isEof()) {
+                break;
+            }
+
+            Optional<Operator> operatorOpt = Operator.find(state.peek());
+            if (operatorOpt.isEmpty()) {
+                break;
+            }
+
+            state.consume();
+            Query right = parseTermQuery(state);
+            left = buildBooleanQuery(left, right, operatorOpt.get());
+        }
+        return left;
+    }
+
+    private Query parseTermQuery(ParserState state) {
+        state.consumeWhitespace();
+        String term = readTerm(state);
+        if (term.isBlank()) {
+            return EmptyQuery.INSTANCE;
+        }
+        return new TermQuery(term);
+    }
+
+    private String readTerm(ParserState state) {
+        int start = state.pos;
+        while (!state.isEof() && !isDelimiter(state.peek())) {
+            state.consume();
+        }
+        return state.text.substring(start, state.pos);
+    }
+
+    private boolean isDelimiter(char c) {
+        return Character.isWhitespace(c) || Operator.find(c).isPresent();
+    }
+
+    private Query buildBooleanQuery(Query left, Query right, Operator operator) {
+        if (left instanceof EmptyQuery) {
+            return right;
+        } else if (right instanceof EmptyQuery) {
+            return left;
+        }
+
+        return switch (operator) {
+            case OR -> buildCompoundQuery(left, right, Occur.SHOULD, Occur.SHOULD);
+            case NOT -> buildCompoundQuery(left, right, Occur.MUST, Occur.MUST_NOT);
+        };
+    }
+
+    private static CompoundQuery buildCompoundQuery(Query leftQuery, Query rightQuery,
+                                                    Occur leftOccur, Occur rightOccur) {
+        return new CompoundQuery(List.of(
+                new Clause(leftQuery, leftOccur),
+                new Clause(rightQuery, rightOccur)
+        ));
+    }
+
+    private static class ParserState {
+        private final String text;
+        private int pos;
+
+        ParserState(String text) {
+            this.text = text;
+            this.pos = 0;
+        }
+
+        char peek() {
+            return text.charAt(pos);
+        }
+
+        char consume() {
+            return text.charAt(pos++);
+        }
+
+        boolean isEof() {
+            return pos >= text.length();
+        }
+
+        void consumeWhitespace() {
+            while (!isEof() && Character.isWhitespace(peek())) {
+                pos++;
+            }
+        }
+    }
+}

--- a/src/main/java/com/nilgil/book/search/parser/model/Clause.java
+++ b/src/main/java/com/nilgil/book/search/parser/model/Clause.java
@@ -1,0 +1,7 @@
+package com.nilgil.book.search.parser.model;
+
+public record Clause(
+        Query query,
+        Occur occur
+) {
+}

--- a/src/main/java/com/nilgil/book/search/parser/model/CompoundQuery.java
+++ b/src/main/java/com/nilgil/book/search/parser/model/CompoundQuery.java
@@ -1,0 +1,11 @@
+package com.nilgil.book.search.parser.model;
+
+import java.util.List;
+
+public record CompoundQuery(
+        List<Clause> clauses
+) implements Query {
+    public CompoundQuery {
+        clauses = clauses == null ? List.of() : clauses;
+    }
+}

--- a/src/main/java/com/nilgil/book/search/parser/model/EmptyQuery.java
+++ b/src/main/java/com/nilgil/book/search/parser/model/EmptyQuery.java
@@ -1,0 +1,8 @@
+package com.nilgil.book.search.parser.model;
+
+public class EmptyQuery implements Query {
+    public static final EmptyQuery INSTANCE = new EmptyQuery();
+
+    private EmptyQuery() {
+    }
+}

--- a/src/main/java/com/nilgil/book/search/parser/model/Occur.java
+++ b/src/main/java/com/nilgil/book/search/parser/model/Occur.java
@@ -1,0 +1,12 @@
+package com.nilgil.book.search.parser.model;
+
+public enum Occur {
+
+    MUST,
+
+    SHOULD,
+
+    MUST_NOT,
+
+    FILTER
+}

--- a/src/main/java/com/nilgil/book/search/parser/model/Query.java
+++ b/src/main/java/com/nilgil/book/search/parser/model/Query.java
@@ -1,0 +1,4 @@
+package com.nilgil.book.search.parser.model;
+
+public interface Query {
+}

--- a/src/main/java/com/nilgil/book/search/parser/model/TermQuery.java
+++ b/src/main/java/com/nilgil/book/search/parser/model/TermQuery.java
@@ -1,0 +1,11 @@
+package com.nilgil.book.search.parser.model;
+
+public record TermQuery(String value) implements Query {
+    public TermQuery {
+        if (value == null) {
+            value = "";
+        } else {
+            value = value.trim();
+        }
+    }
+}

--- a/src/test/java/com/nilgil/book/search/parser/SimpleQueryParserTest.java
+++ b/src/test/java/com/nilgil/book/search/parser/SimpleQueryParserTest.java
@@ -1,0 +1,98 @@
+package com.nilgil.book.search.parser;
+
+import com.nilgil.book.search.parser.model.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleQueryParserTest {
+
+    private final QueryParser parser = new SimpleQueryParser();
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("빈 값이나 null 입력 시 EmptyQuery를 반환한다")
+    void parseEmptyQuery(String input) {
+        // when
+        Query query = parser.parse(input);
+
+        // then
+        assertThat(query).isInstanceOf(EmptyQuery.class);
+    }
+
+    @Test
+    @DisplayName("단일 검색어는 TermQuery로 파싱된다")
+    void parseSingleTerm() {
+        // given
+        String input = "book";
+
+        // when
+        Query query = parser.parse(input);
+
+        // then
+        assertThat(query).isInstanceOfSatisfying(TermQuery.class, termQuery ->
+                assertThat(termQuery.value()).isEqualTo("book"));
+    }
+
+    @Test
+    @DisplayName("OR 연산자(|)로 구분된 검색어는 모두 SHOULD 조건으로 CompoundQuery에 포함된다")
+    void parseOrQuery() {
+        // given
+        String input = "book|author";
+
+        // when
+        Query query = parser.parse(input);
+
+        // then
+        assertThat(query).isInstanceOfSatisfying(CompoundQuery.class, compoundQuery ->
+                assertThat(compoundQuery.clauses())
+                        .hasSize(2)
+                        .extracting(Clause::occur)
+                        .containsExactly(Occur.SHOULD, Occur.SHOULD));
+    }
+
+    @Test
+    @DisplayName("NOT 연산자(-)로 구분된 검색어는 MUST와 MUST_NOT 조건으로 CompoundQuery에 포함된다")
+    void parseNotQuery() {
+        // given
+        String input = "book-author";
+
+        // when
+        Query query = parser.parse(input);
+
+        // then
+        assertThat(query).isInstanceOfSatisfying(CompoundQuery.class, compoundQuery ->
+                assertThat(compoundQuery.clauses())
+                        .hasSize(2)
+                        .extracting(Clause::occur)
+                        .containsExactly(Occur.MUST, Occur.MUST_NOT));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  book  ", "  book  |  author  ", "  book  -  author  "})
+    @DisplayName("앞뒤 공백이 포함된 TermQuery는 공백이 제거된 형태로 파싱된다")
+    void parseNormalizedSingleTerm(String input) {
+        // when
+        Query query = parser.parse(input);
+
+        // then
+        if (query instanceof TermQuery(String value)) {
+
+            assertThat(value).isEqualTo("book");
+
+        } else if (query instanceof CompoundQuery(List<Clause> clauses)) {
+
+            assertThat(clauses)
+                    .hasSize(2)
+                    .extracting(c -> ((TermQuery) c.query()).value())
+                    .containsExactly("book", "author");
+
+        }
+    }
+}


### PR DESCRIPTION
Closes #6

### 변경 사항
앞으로의 확장을 위해 검색 DSL을 자체적인 추상화를 통해 AST로 만드는 과정이 필요했습니다. Apache Lucene을 참고하여 현재 상황에 맞게 최소화하여 만들어 보았습니다.

### 추가 내용
- 확장성을 위한 lucene 스타일 queryModel 추가
- 현재 요구사항에 맞춘 간단한 쿼리 파서 추가